### PR TITLE
Fix EC2 terraform configuration

### DIFF
--- a/iac/deployment/main.tf
+++ b/iac/deployment/main.tf
@@ -15,8 +15,7 @@ module "wb_network" {
 resource "aws_instance" "wb_ec2" {
   ami                    = var.ami_id
   instance_type          = "t3.micro"
-#  vpc_security_group_ids = [aws_security_group.wb_sg.id]
-  security_groups        = [module.wb_network.security_group_id]
+  vpc_security_group_ids = [module.wb_network.security_group_id]
   subnet_id              = module.wb_network.subnet_id
 
   tags = {


### PR DESCRIPTION
From [this issue](https://github.com/hashicorp/terraform/issues/7221), it seems the current configuration of the security group makes the EC2 instance to be destroyed and created in every apply.

This PR fixes it.